### PR TITLE
ci: turn off additional golangci-lint checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Linter
       uses: reviewdog/action-golangci-lint@v2
-      with:
-        golangci_lint_flags: "--default all"
 
   commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Using all checks is too much. Just use the ones specified in the config.